### PR TITLE
fix README.md link typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The pipeline stops/exits on encountering a failure at any of the below stages. T
 
 ## Deployment
 1. [AWS CodePipeline for deploying Terraform resources](https://github.com/aws-samples/aws-devops-pipeline-accelerator/blob/main/aws-codepipeline/terraform/README.md)
-2. [AWS CodePipeline for deploying CloudFormation resources](https://github.com/aws-samples/aws-devops-pipeline-accelerator/blob/main/aws-codepipeline/terraform/README.md)
+2. [AWS CodePipeline for deploying CloudFormation resources](https://github.com/aws-samples/aws-devops-pipeline-accelerator/blob/main/aws-codepipeline/cloudformation/README.md)
 3. [Gitlab CI for deploying Terraform, CDK and CloudFormation resources](https://github.com/aws-samples/aws-devops-pipeline-accelerator/blob/main/gitlab-ci/README.md)
 
 ## Benefits


### PR DESCRIPTION
docs(README.md): update cloudformation link to point to appropriate documentation instead of terraform docs

*Description of changes:*
updated the README.md to point to the documentation for deploying CloudFormation resources instead of incorrectly pointing to the terraform documentation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
